### PR TITLE
Make code of conduct link visible

### DIFF
--- a/web/assets/css/site.css
+++ b/web/assets/css/site.css
@@ -50,6 +50,9 @@ a:hover {
   background: #e24b3b;
   color: #FFF;
 }
+.section--primary a {
+  color: #333;
+}
 
 .section--light {
   background: #EEE;


### PR DESCRIPTION
Couldn't go with white, so went with not-quite-black.
![coc-link](https://cloud.githubusercontent.com/assets/98873/11973258/a2188698-a94f-11e5-93f9-3a96eefceae0.png)
